### PR TITLE
fix(repo): setup pnpm workspace with Nx and new TS project references

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
     "tslib": "^2.3.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.13.0"
-  },
-  "workspaces": [
-    "packages/*"
-  ]
+  }
 }

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "tslib": "^2.3.0",
-    "@css-nx/utils": "*"
+    "@css-nx/utils": "workspace:*"
   },
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,15 @@ importers:
 
   packages/cart:
     dependencies:
+      '@css-nx/utils':
+        specifier: workspace:*
+        version: link:../utils
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
+  packages/utils:
+    dependencies:
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
pnpm supports using the `workspace:` prefix for referencing other packages within the pnpm workspace: https://pnpm.io/workspaces#referencing-workspace-packages-through-aliases

without pnpm will attempt to resolve from the registry and can cause funky issues like:
```
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@css-nx%2Futils: Not Found - 404
```

this change updated the lock file for pnpm to reference the local workspace file.

also remove the package.json#workspaces key as that is only for npm and yarn, pnpm use `pnpm-workspaces.yaml` instead. (didn't break anything just had pnpm logging warnings)


![WKMac 2024-12-18T21-47-24](https://github.com/user-attachments/assets/d7515cc0-3209-47f6-9666-c0779ae7e4a2)
